### PR TITLE
fix: use reflection to cast arguments

### DIFF
--- a/src/ViewModel/Imgproxy.php
+++ b/src/ViewModel/Imgproxy.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elgentos\Imgproxy\ViewModel;
+
+use Elgentos\Imgproxy\Model\Image;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+class Imgproxy implements ArgumentInterface
+{
+    public function __construct(
+        private readonly Image $image,
+    ) {
+    }
+
+    public function getCustomUrl(string $currentUrl, int $width, int $height): string
+    {
+        return $this->image->getCustomUrl($currentUrl, $width, $height);
+    }
+}


### PR DESCRIPTION
- Check if the method exists with reflection.
- Cast arguments with reflection to cast to all needed types.
- Removed the `convertCustomProcessingOptionsToInt` function because it's handled with reflection now.
- Created a small ViewModel to get some Imgproxy urls in templates.

For example, `WatermarkConfig:0.4:ce:::0.4` will work now. 